### PR TITLE
fix apple silicon builds [ci build]

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,22 +13,36 @@ on:
 
 jobs:
   build_wheels:
-    name: Build wheels on ${{ matrix.os }}
 
     # Only run if the commit message contains '[ci build]' OR always run if it's a tag
     # This will not respect the tag if it appears in a pull request commit message. Those builds always show up as 'synchronize' events, and there is no easy way to get the corresponding commit messages. We instead pull the PR title to check for tags.
     # More info here: https://github.community/t/accessing-commit-message-in-pull-request-event/17158/13
     if: "contains(toJSON(github.event.commits.*.message), '[ci build]') || contains(toJSON(github.event.pull_request.title), '[ci build]') || contains(github.ref, 'refs/tags')"
 
-    runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-18.04, windows-2019, macos-10.15]
+        include:
+          - runs-on: ubuntu-latest
+            cibw-arch: manylinux_x86_64
+          - runs-on: ubuntu-latest
+            cibw-arch: manylinux_i686
+          - runs-on: macos-latest
+            cibw-arch: macosx_x86_64
+          - runs-on: macos-latest
+            cibw-arch: macosx_arm64
+          - runs-on: macos-latest
+            cibw-arch: macosx_universal2
+          - runs-on: windows-latest
+            cibw-arch: win_amd64
+          - runs-on: windows-latest
+            cibw-arch: win32
+            python-arch: x86
+
+    name: Wheels • ${{ matrix.cibw-arch }}
+    runs-on: ${{ matrix.runs-on }}
+
     env:
       CIBW_BUILD_VERBOSITY: 3
-      CIBW_BUILD: "cp3*-manylinux_x86_64 cp3*-manylinux_i686 cp3*-macosx_x86_64 cp3*-macosx_universal2 cp3*-macosx_arm64 cp3*-win_amd64 cp3*-win32" 
-      #CIBW_BUILD: "cp36-manylinux_x86_64 cp36-manylinux_i686 cp36-macosx_x86_64 cp36-win_amd64 cp36-win32" # a few wheels for quick test runs
-      CIBW_ARCHS_MACOS: "x86_64 universal2 arm64"
       CIBW_BEFORE_BUILD_LINUX : "yum remove -y cmake && python -m pip install cmake"
 
     steps:
@@ -51,6 +65,15 @@ jobs:
         if: runner.os == 'Linux'
         run: |
           python setup.py sdist -d wheelhouse --formats=gztar 
+
+      - name: Configure cibuildwheel
+        shell: bash
+        run: |
+          CMAKE_ARCH="${{ matrix.cibw-arch == 'win32' && '-A Win32' || '' }}"
+          CMAKE_OSX_ARCHITECTURES=${{ matrix.cibw-arch == 'macosx_x86_64' && 'x86_64' || matrix.cibw-arch == 'macosx_arm64' && 'arm64' || matrix.cibw-arch == 'macosx_universal2' && '"arm64;x86_64"' || '' }}
+          echo "CIBW_ARCHS_MACOS=x86_64 arm64 universal2" >> $GITHUB_ENV
+          echo "CIBW_BUILD=*-${{ matrix.cibw-arch }}" >> $GITHUB_ENV
+          echo "CIBW_ENVIRONMENT_MACOS=CMAKE_OSX_ARCHITECTURES=\"$CMAKE_OSX_ARCHITECTURES\"" >> $GITHUB_ENV
 
       - name: Build wheels
         run: |


### PR DESCRIPTION
The previous fix for apple silicon builds was not correctly configuring CMake to build for the correct target architecture. The approach implemented here patterns off of that used in [parselmouth](https://github.com/YannickJadoul/Parselmouth/blob/master/.github/workflows/wheels.yml) in which the matrix of build targets is manually configured so that the correct environment variables can be specified at run time. In particular `CMAKE_OSX_ARCHITECTURES` must be set so that CMake builds for the correct architecture.

This approach is a little awkward, I would expect CIBuildWheel to be updated so that it can do this for us. As noted by the robust-laplacian package maintainer, other build systems such as scikit-build already do this correctly.